### PR TITLE
⚙️ [Maintenance]: Hard-lock Pester test dependency to 5.8.0 by GUID

### DIFF
--- a/tests/Context.Tests.ps1
+++ b/tests/Context.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.7.1' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.8.0'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSUseDeclaredVarsMoreThanAssignments', '',

--- a/tests/ContextVaults.Tests.ps1
+++ b/tests/ContextVaults.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.7.1' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.8.0'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSUseDeclaredVarsMoreThanAssignments', '',


### PR DESCRIPTION
Hard-locks the Pester test dependency to an exact version pinned by module GUID, replacing the `RequiredVersion = '5.7.1'` pin that broke test discovery when the runner installed Pester 5.8.0.

```powershell
#Requires -Modules @{ ModuleName = 'Pester'; RequiredVersion = '5.8.0'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
```

## Why 5.8.0 + GUID
- **Exact version** = reproducible and supply-chain-safe (no silent drift to a newer or compromised release).
- **GUID** pins module identity (anti-name-squat). Both the version and the GUID are enforced by PowerShell at discovery time (verified locally).
- **No version comment** — unlike a GitHub Actions `@<sha>`, `RequiredVersion` already states the version in plain text, and `#Requires` rejects a GUID without a version key.

Files updated: 2 test file(s).

Fixes #118.

> [!NOTE]
> This pin fully holds once `Invoke-Pester` installs the pinned version instead of the latest (today it installs newest, so a future Pester release would re-break exact pins). Tracked in PSModule/Invoke-Pester#68. Part of the dependency-management epic PSModule/Process-PSModule#356.
